### PR TITLE
feat(visualization): Refactor VisualizationSet to align with VTK

### DIFF
--- a/ladybug_display/_base.py
+++ b/ladybug_display/_base.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """Base class for all geometry objects."""
 LINE_TYPES = ('Continuous', 'Dashed', 'Dotted', 'DashDot', 'Center', 'Border', 'Hidden')
-DISPLAY_MODES = ('Shaded', 'Surface', 'SurfaceWithEdges', 'Wireframe')
+DISPLAY_MODES = ('Surface', 'SurfaceWithEdges', 'Wireframe', 'Points')
 
 
 class _DisplayBase(object):

--- a/ladybug_display/geometry2d/mesh.py
+++ b/ladybug_display/geometry2d/mesh.py
@@ -14,13 +14,13 @@ class DisplayMesh2D(_DisplayBase2D):
         colors: A list of colors that correspond to either the faces of the mesh
             or the vertices of the mesh. It can also be a single color for the
             entire mesh. (Default: None).
-        display_mode: Text to indicate the display mode (shaded, wireframe, etc.).
-            Choose from the following. (Default: Shaded).
+        display_mode: Text to indicate the display mode (surface, wireframe, etc.).
+            Choose from the following. (Default: Surface).
 
-            * Shaded
             * Surface
             * SurfaceWithEdges
             * Wireframe
+            * Points
 
     Properties:
         * geometry
@@ -38,7 +38,7 @@ class DisplayMesh2D(_DisplayBase2D):
     """
     __slots__ = ('_colors', '_display_mode')
 
-    def __init__(self, geometry, colors=None, display_mode='Shaded'):
+    def __init__(self, geometry, colors=None, display_mode='Surface'):
         """Initialize base with shade object."""
         assert isinstance(geometry, Mesh2D), '\
             Expected ladybug_geometry Mesh2D. Got {}'.format(type(geometry))
@@ -58,7 +58,7 @@ class DisplayMesh2D(_DisplayBase2D):
         colors = [Color.from_dict(c) for c in data['colors']] if 'colors' in data \
             and data['colors'] is not None else None
         d_mode = data['display_mode'] if 'display_mode' in data and \
-            data['display_mode'] is not None else 'Shaded'
+            data['display_mode'] is not None else 'Surface'
         geo = cls(Mesh2D.from_dict(data['geometry']), colors, d_mode)
         if 'user_data' in data and data['user_data'] is not None:
             geo.user_data = data['user_data']

--- a/ladybug_display/geometry2d/polygon.py
+++ b/ladybug_display/geometry2d/polygon.py
@@ -13,13 +13,13 @@ class DisplayPolygon2D(_SingleColorBase2D):
         geometry: A ladybug-geometry Polygon2D object.
         color: A ladybug Color object. If None, a default black color will be
             used. (Default: None).
-        display_mode: Text to indicate the display mode (shaded, wireframe, etc.).
-            Choose from the following. (Default: Shaded).
+        display_mode: Text to indicate the display mode (surface, wireframe, etc.).
+            Choose from the following. (Default: Surface).
 
-            * Shaded
             * Surface
             * SurfaceWithEdges
             * Wireframe
+            * Points
 
     Properties:
         * geometry
@@ -39,7 +39,7 @@ class DisplayPolygon2D(_SingleColorBase2D):
     """
     __slots__ = ('_display_mode',)
 
-    def __init__(self, geometry, color=None, display_mode='Shaded'):
+    def __init__(self, geometry, color=None, display_mode='Surface'):
         """Initialize base with shade object."""
         assert isinstance(geometry, Polygon2D), '\
             Expected ladybug_geometry Polygon2D. Got {}'.format(type(geometry))
@@ -58,7 +58,7 @@ class DisplayPolygon2D(_SingleColorBase2D):
         color = Color.from_dict(data['color']) if 'color' in data and data['color'] \
             is not None else None
         d_mode = data['display_mode'] if 'display_mode' in data and \
-            data['display_mode'] is not None else 'Shaded'
+            data['display_mode'] is not None else 'Surface'
         geo = cls(Polygon2D.from_dict(data['geometry']), color, d_mode)
         if 'user_data' in data and data['user_data'] is not None:
             geo.user_data = data['user_data']

--- a/ladybug_display/geometry3d/_base.py
+++ b/ladybug_display/geometry3d/_base.py
@@ -120,8 +120,8 @@ class _SingleColorModeBase3D(_SingleColorBase3D):
         geometry: A ladybug-geometry object.
         color: A ladybug Color object. If None, a default black color will be
             used. (Default: None).
-        display_mode: Text to indicate the display mode (shaded, wireframe, etc.).
-            Choose from the following. (Default: Shaded).
+        display_mode: Text to indicate the display mode (surface, wireframe, etc.).
+            Choose from the following. (Default: Surface).
 
     Properties:
         * geometry
@@ -131,7 +131,7 @@ class _SingleColorModeBase3D(_SingleColorBase3D):
     """
     __slots__ = ('_display_mode',)
 
-    def __init__(self, geometry, color=None, display_mode='Shaded'):
+    def __init__(self, geometry, color=None, display_mode='Surface'):
         """Initialize object."""
         _SingleColorBase3D.__init__(self, geometry, color)
         self.display_mode = display_mode

--- a/ladybug_display/geometry3d/cone.py
+++ b/ladybug_display/geometry3d/cone.py
@@ -12,13 +12,13 @@ class DisplayCone(_SingleColorModeBase3D):
         geometry: A ladybug-geometry Cone.
         color: A ladybug Color object. If None, a default black color will be
             used. (Default: None).
-        display_mode: Text to indicate the display mode (shaded, wireframe, etc.).
-            Choose from the following. (Default: Shaded).
+        display_mode: Text to indicate the display mode (surface, wireframe, etc.).
+            Choose from the following. (Default: Surface).
 
-            * Shaded
             * Surface
             * SurfaceWithEdges
             * Wireframe
+            * Points
 
     Properties:
         * geometry
@@ -34,7 +34,7 @@ class DisplayCone(_SingleColorModeBase3D):
     """
     __slots__ = ()
 
-    def __init__(self, geometry, color=None, display_mode='Shaded'):
+    def __init__(self, geometry, color=None, display_mode='Surface'):
         """Initialize base with shade object."""
         assert isinstance(geometry, Cone), '\
             Expected ladybug_geometry Cone. Got {}'.format(type(geometry))
@@ -52,7 +52,7 @@ class DisplayCone(_SingleColorModeBase3D):
         color = Color.from_dict(data['color']) if 'color' in data and data['color'] \
             is not None else None
         d_mode = data['display_mode'] if 'display_mode' in data and \
-            data['display_mode'] is not None else 'Shaded'
+            data['display_mode'] is not None else 'Surface'
         geo = cls(Cone.from_dict(data['geometry']), color, d_mode)
         if 'user_data' in data and data['user_data'] is not None:
             geo.user_data = data['user_data']

--- a/ladybug_display/geometry3d/cylinder.py
+++ b/ladybug_display/geometry3d/cylinder.py
@@ -12,13 +12,13 @@ class DisplayCylinder(_SingleColorModeBase3D):
         geometry: A ladybug-geometry Cylinder.
         color: A ladybug Color object. If None, a default black color will be
             used. (Default: None).
-        display_mode: Text to indicate the display mode (shaded, wireframe, etc.).
-            Choose from the following. (Default: Shaded).
+        display_mode: Text to indicate the display mode (surface, wireframe, etc.).
+            Choose from the following. (Default: Surface).
 
-            * Shaded
             * Surface
             * SurfaceWithEdges
             * Wireframe
+            * Points
 
     Properties:
         * geometry
@@ -34,7 +34,7 @@ class DisplayCylinder(_SingleColorModeBase3D):
     """
     __slots__ = ()
 
-    def __init__(self, geometry, color=None, display_mode='Shaded'):
+    def __init__(self, geometry, color=None, display_mode='Surface'):
         """Initialize base with shade object."""
         assert isinstance(geometry, Cylinder), '\
             Expected ladybug_geometry Cylinder. Got {}'.format(type(geometry))
@@ -52,7 +52,7 @@ class DisplayCylinder(_SingleColorModeBase3D):
         color = Color.from_dict(data['color']) if 'color' in data and data['color'] \
             is not None else None
         d_mode = data['display_mode'] if 'display_mode' in data and \
-            data['display_mode'] is not None else 'Shaded'
+            data['display_mode'] is not None else 'Surface'
         geo = cls(Cylinder.from_dict(data['geometry']), color, d_mode)
         if 'user_data' in data and data['user_data'] is not None:
             geo.user_data = data['user_data']

--- a/ladybug_display/geometry3d/face.py
+++ b/ladybug_display/geometry3d/face.py
@@ -14,13 +14,13 @@ class DisplayFace3D(_SingleColorModeBase3D):
         geometry: A ladybug-geometry Face3D.
         color: A ladybug Color object. If None, a default black color will be
             used. (Default: None).
-        display_mode: Text to indicate the display mode (shaded, wireframe, etc.).
-            Choose from the following. (Default: Shaded).
+        display_mode: Text to indicate the display mode (surface, wireframe, etc.).
+            Choose from the following. (Default: Surface).
 
-            * Shaded
             * Surface
             * SurfaceWithEdges
             * Wireframe
+            * Points
 
     Properties:
         * geometry
@@ -39,7 +39,7 @@ class DisplayFace3D(_SingleColorModeBase3D):
     """
     __slots__ = ()
 
-    def __init__(self, geometry, color=None, display_mode='Shaded'):
+    def __init__(self, geometry, color=None, display_mode='Surface'):
         """Initialize object."""
         assert isinstance(geometry, Face3D), '\
             Expected ladybug_geometry Face3D. Got {}'.format(type(geometry))
@@ -57,7 +57,7 @@ class DisplayFace3D(_SingleColorModeBase3D):
         color = Color.from_dict(data['color']) if 'color' in data and data['color'] \
             is not None else None
         d_mode = data['display_mode'] if 'display_mode' in data and \
-            data['display_mode'] is not None else 'Shaded'
+            data['display_mode'] is not None else 'Surface'
         geo = cls(Face3D.from_dict(data['geometry']), color, d_mode)
         if 'user_data' in data and data['user_data'] is not None:
             geo.user_data = data['user_data']

--- a/ladybug_display/geometry3d/mesh.py
+++ b/ladybug_display/geometry3d/mesh.py
@@ -14,13 +14,13 @@ class DisplayMesh3D(_DisplayBase3D):
         colors: A list of colors that correspond to either the faces of the mesh
             or the vertices of the mesh. It can also be a single color for the
             entire mesh. (Default: None).
-        display_mode: Text to indicate the display mode (shaded, wireframe, etc.).
-            Choose from the following. (Default: Shaded).
+        display_mode: Text to indicate the display mode (surface, wireframe, etc.).
+            Choose from the following. (Default: Surface).
 
-            * Shaded
             * Surface
             * SurfaceWithEdges
             * Wireframe
+            * Points
 
     Properties:
         * geometry
@@ -40,7 +40,7 @@ class DisplayMesh3D(_DisplayBase3D):
     """
     __slots__ = ('_colors', '_display_mode')
 
-    def __init__(self, geometry, colors=None, display_mode='Shaded'):
+    def __init__(self, geometry, colors=None, display_mode='Surface'):
         """Initialize base with shade object."""
         assert isinstance(geometry, Mesh3D), '\
             Expected ladybug_geometry Mesh3D. Got {}'.format(type(geometry))
@@ -60,7 +60,7 @@ class DisplayMesh3D(_DisplayBase3D):
         colors = [Color.from_dict(c) for c in data['colors']] if 'colors' in data \
             and data['colors'] is not None else None
         d_mode = data['display_mode'] if 'display_mode' in data and \
-            data['display_mode'] is not None else 'Shaded'
+            data['display_mode'] is not None else 'Surface'
         geo = cls(Mesh3D.from_dict(data['geometry']), colors, d_mode)
         if 'user_data' in data and data['user_data'] is not None:
             geo.user_data = data['user_data']

--- a/ladybug_display/geometry3d/polyface.py
+++ b/ladybug_display/geometry3d/polyface.py
@@ -14,13 +14,13 @@ class DisplayPolyface3D(_DisplayBase3D):
         colors: A list of colors that correspond to either the faces of the polyface
             or the vertices of the polyface. It can also be a single color for the
             entire polyface. (Default: None).
-        display_mode: Text to indicate the display mode (shaded, wireframe, etc.).
-            Choose from the following. (Default: Shaded).
+        display_mode: Text to indicate the display mode (surface, wireframe, etc.).
+            Choose from the following. (Default: Surface).
 
-            * Shaded
             * Surface
             * SurfaceWithEdges
             * Wireframe
+            * Points
 
     Properties:
         * geometry
@@ -45,7 +45,7 @@ class DisplayPolyface3D(_DisplayBase3D):
     """
     __slots__ = ('_colors', '_display_mode')
 
-    def __init__(self, geometry, colors=None, display_mode='Shaded'):
+    def __init__(self, geometry, colors=None, display_mode='Surface'):
         """Initialize base with shade object."""
         assert isinstance(geometry, Polyface3D), '\
             Expected ladybug_geometry Polyface3D. Got {}'.format(type(geometry))
@@ -65,7 +65,7 @@ class DisplayPolyface3D(_DisplayBase3D):
         colors = [Color.from_dict(c) for c in data['colors']] if 'colors' in data \
             and data['colors'] is not None else None
         d_mode = data['display_mode'] if 'display_mode' in data and \
-            data['display_mode'] is not None else 'Shaded'
+            data['display_mode'] is not None else 'Surface'
         geo = cls(Polyface3D.from_dict(data['geometry']), colors, d_mode)
         if 'user_data' in data and data['user_data'] is not None:
             geo.user_data = data['user_data']

--- a/ladybug_display/geometry3d/sphere.py
+++ b/ladybug_display/geometry3d/sphere.py
@@ -12,13 +12,13 @@ class DisplaySphere(_SingleColorModeBase3D):
         geometry: A ladybug-geometry Sphere.
         color: A ladybug Color object. If None, a default black color will be
             used. (Default: None).
-        display_mode: Text to indicate the display mode (shaded, wireframe, etc.).
-            Choose from the following. (Default: Shaded).
+        display_mode: Text to indicate the display mode (surface, wireframe, etc.).
+            Choose from the following. (Default: Surface).
 
-            * Shaded
             * Surface
             * SurfaceWithEdges
             * Wireframe
+            * Points
 
     Properties:
         * geometry
@@ -36,7 +36,7 @@ class DisplaySphere(_SingleColorModeBase3D):
     """
     __slots__ = ()
 
-    def __init__(self, geometry, color=None, display_mode='Shaded'):
+    def __init__(self, geometry, color=None, display_mode='Surface'):
         """Initialize base with shade object."""
         assert isinstance(geometry, Sphere), '\
             Expected ladybug_geometry Sphere. Got {}'.format(type(geometry))
@@ -54,7 +54,7 @@ class DisplaySphere(_SingleColorModeBase3D):
         color = Color.from_dict(data['color']) if 'color' in data and data['color'] \
             is not None else None
         d_mode = data['display_mode'] if 'display_mode' in data and \
-            data['display_mode'] is not None else 'Shaded'
+            data['display_mode'] is not None else 'Surface'
         geo = cls(Sphere.from_dict(data['geometry']), color, d_mode)
         if 'user_data' in data and data['user_data'] is not None:
             geo.user_data = data['user_data']

--- a/ladybug_display/typing.py
+++ b/ladybug_display/typing.py
@@ -1,4 +1,5 @@
 """Collection of methods for type input checking."""
+import re
 import math
 
 try:
@@ -8,6 +9,22 @@ except AttributeError:
     # python 2
     INFPOS = float('inf')
     INFNEG = float('-inf')
+
+
+def valid_string(value, input_name=''):
+    """Check that a string is valid as an identifier."""
+    try:
+        illegal_match = re.search(r'[^.A-Za-z0-9_-]', value)
+    except TypeError:
+        raise TypeError('Input {} must be a text string. Got {}: {}.'.format(
+            input_name, type(value), value))
+    assert illegal_match is None, 'Illegal character "{}" found in {}'.format(
+        illegal_match.group(0), input_name)
+    assert len(value) > 0, 'Input {} "{}" contains no characters.'.format(
+        input_name, value)
+    assert len(value) <= 100, 'Input {} "{}" must be less than 100 characters.'.format(
+        input_name, value)
+    return value
 
 
 def _number_check(value, input_name):

--- a/tests/cone_test.py
+++ b/tests/cone_test.py
@@ -15,7 +15,7 @@ def test_cone_init():
     str(c)  # test the string representation of the cone
 
     assert c.color == grey
-    assert c.display_mode == 'Shaded'
+    assert c.display_mode == 'Surface'
     assert c.vertex == Point3D(2, 0, 2)
     assert c.axis == Vector3D(0, 2, 2)
     assert c.height == c.axis.magnitude

--- a/tests/cylinder_test.py
+++ b/tests/cylinder_test.py
@@ -15,7 +15,7 @@ def test_cylinder_init():
     str(c)  # test the string representation of the cylinder
 
     assert c.color == grey
-    assert c.display_mode == 'Shaded'
+    assert c.display_mode == 'Surface'
     assert c.center == Point3D(2, 0, 2)
     assert c.axis == Vector3D(0, 2, 2)
     assert c.radius == 0.7

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -15,7 +15,7 @@ def test_display_face3d_init():
     str(face)  # test the string representation of the face
 
     assert face.color == grey
-    assert face.display_mode == 'Shaded'
+    assert face.display_mode == 'Surface'
     assert isinstance(face.vertices, tuple)
     assert len(face.vertices) == 4
     for point in face.vertices:

--- a/tests/mesh2d_test.py
+++ b/tests/mesh2d_test.py
@@ -13,7 +13,7 @@ def test_display_mesh2d_init():
     mesh = DisplayMesh2D(Mesh2D(pts, [(0, 1, 2, 3), (2, 3, 4)]), [grey])
 
     assert mesh.colors == (grey,)
-    assert mesh.display_mode == 'Shaded'
+    assert mesh.display_mode == 'Surface'
     assert len(mesh.vertices) == 5
     assert len(mesh.faces) == 2
     assert mesh.area == 6

--- a/tests/mesh3d_test.py
+++ b/tests/mesh3d_test.py
@@ -13,7 +13,7 @@ def test_display_mesh3d_init():
     mesh = DisplayMesh3D(Mesh3D(pts, [(0, 1, 2, 3), (2, 3, 4)]), [grey])
 
     assert mesh.colors == (grey,)
-    assert mesh.display_mode == 'Shaded'
+    assert mesh.display_mode == 'Surface'
     assert len(mesh.vertices) == 5
     assert len(mesh.faces) == 2
     assert mesh.area == 6

--- a/tests/polyface3d_test.py
+++ b/tests/polyface3d_test.py
@@ -15,7 +15,7 @@ def test_polyface3d_init_solid():
     polyface = DisplayPolyface3D(Polyface3D(pts, face_indices), [grey])
 
     assert polyface.colors == (grey,)
-    assert polyface.display_mode == 'Shaded'
+    assert polyface.display_mode == 'Surface'
     assert len(polyface.vertices) == 8
     assert len(polyface.face_indices) == 6
     assert len(polyface.faces) == 6

--- a/tests/polygon2d_test.py
+++ b/tests/polygon2d_test.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from ladybug_geometry.geometry2d.pointvector import Point2D, Vector2D
+from ladybug_geometry.geometry2d.pointvector import Point2D
 from ladybug_geometry.geometry2d.polygon import Polygon2D
 from ladybug.color import Color
 from ladybug_display.geometry2d.polygon import DisplayPolygon2D
@@ -13,7 +13,7 @@ def test_display_p_gon2d_init():
     str(p_gon)  # test the string representation of the p_gon
 
     assert p_gon.color == grey
-    assert p_gon.display_mode == 'Shaded'
+    assert p_gon.display_mode == 'Surface'
     assert isinstance(p_gon.vertices, tuple)
     assert len(p_gon.vertices) == 4
     for point in p_gon.vertices:

--- a/tests/sphere_test.py
+++ b/tests/sphere_test.py
@@ -14,7 +14,7 @@ def test_display_sphere_init():
     str(sp)  # test the string representation of the line segment
 
     assert sp.color == grey
-    assert sp.display_mode == 'Shaded'
+    assert sp.display_mode == 'Surface'
     assert sp.center == Point3D(2, 0, 2)
     assert sp.radius == 3
     assert sp.min.z == -1

--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -8,20 +8,20 @@ from ladybug_geometry.geometry3d.polyface import Polyface3D
 from ladybug.graphic import GraphicContainer
 from ladybug.legend import Legend, LegendParameters
 
-from ladybug_display.visualization import VisualizationSet, AnalysisGeometry, \
-    VisualizationData
+from ladybug_display.visualization import VisualizationSet, ContextGeometry, \
+    AnalysisGeometry, VisualizationData
 
 
 def test_init_visualization_set():
     """Test the initialization of VisualizationSet objects."""
-    context = Polyface3D.from_box(2, 4, 2, base_plane=Plane(o=Point3D(0, 2, 0)))
+    con_geo = Polyface3D.from_box(2, 4, 2, base_plane=Plane(o=Point3D(0, 2, 0)))
+    context = ContextGeometry('Building_Massing', [con_geo])
     mesh2d = Mesh2D.from_grid(num_x=2, num_y=2)
     mesh3d = Mesh3D.from_mesh2d(mesh2d)
     data = VisualizationData([0, 1, 2, 3])
-    a_geo = AnalysisGeometry([mesh3d], [data])
-    vis_set = VisualizationSet([a_geo], [context])
-
-    str(vis_set)  # Test the GraphicContainer representation
+    a_geo = AnalysisGeometry('Test_Results', [mesh3d], [data])
+    vis_set = VisualizationSet('Test_Set', [a_geo, context])
+    str(vis_set)
 
     assert a_geo.matching_method == 'faces'
     assert len(data) == 4
@@ -50,7 +50,8 @@ def test_init_visualization_set():
 
 def test_init_visualization_set_legend_parameters():
     """Test the initialization of VisualizationSet objects with a LegendParameters."""
-    context = Polyface3D.from_box(2, 4, 2, base_plane=Plane(o=Point3D(0, 2, 0)))
+    con_geo = Polyface3D.from_box(2, 4, 2, base_plane=Plane(o=Point3D(0, 2, 0)))
+    context = ContextGeometry('Building_Massing', [con_geo])
     mesh2d = Mesh2D.from_grid(num_x=2, num_y=2)
     mesh3d = Mesh3D.from_mesh2d(mesh2d)
     legend_par = LegendParameters(base_plane=Plane(o=Point3D(2, 2, 0)))
@@ -59,8 +60,8 @@ def test_init_visualization_set_legend_parameters():
     legend_par.segment_width = 0.5
     legend_par.text_height = 0.15
     data = VisualizationData([-1, 0, 1, 2], legend_par)
-    a_geo = AnalysisGeometry([mesh3d], [data])
-    vis_set = VisualizationSet([a_geo], [context])
+    a_geo = AnalysisGeometry('Test_Results', [mesh3d], [data])
+    vis_set = VisualizationSet('Test_Set', [a_geo, context])
 
     graphic_con = vis_set.graphic_container()
     assert not graphic_con.legend_parameters.is_base_plane_default
@@ -76,12 +77,13 @@ def test_init_visualization_set_legend_parameters():
 
 def test_to_from_dict():
     """Test the to/from dict methods."""
-    context = Polyface3D.from_box(2, 4, 2, base_plane=Plane(o=Point3D(0, 2, 0)))
+    con_geo = Polyface3D.from_box(2, 4, 2, base_plane=Plane(o=Point3D(0, 2, 0)))
+    context = ContextGeometry('Building_Massing', [con_geo])
     mesh2d = Mesh2D.from_grid(num_x=2, num_y=2)
     mesh3d = Mesh3D.from_mesh2d(mesh2d)
     data = VisualizationData([0, 1, 2, 3])
-    a_geo = AnalysisGeometry([mesh3d], [data])
-    vis_set = VisualizationSet([a_geo], [context])
+    a_geo = AnalysisGeometry('Test_Results', [mesh3d], [data])
+    vis_set = VisualizationSet('Test_Set', [a_geo, context])
 
     vis_set_dict = vis_set.to_dict()
     new_vis_set = VisualizationSet.from_dict(vis_set_dict)


### PR DESCRIPTION
This includes the following:

* Create a ContextGeometry object (similar to the AnalysisGeometry object)
* Add display_name and identifier to AnalysisGeometry and ContextGeometry. This display_name will determine the layer onto which the geometry objects are written. We will use the Rhino convention for specifying sub-layers by separating the parent::child with ::
* Instead of having separate properties on the VisualizationSet for context_geometry and analysis_geometry, just make one "geometry" property that contains a flat list of context and analysis geometries. This will allow people to customize the order of layers and alternate between context and analysis geometries.
* Add a validation routine to check for unique identifiers for the context and analysis geometry
* Change the display_mode enumeration to not have "Shaded" (this has no meaning for VTK or Rhino) and instead have "Points" (which has meaning for VTK and Rhino)
* Add a display_mode option to AnalysisGeometry, which will allow users to choose whether they want the meshes to display with edges or not.